### PR TITLE
Fix saving custom templates

### DIFF
--- a/src/lib/template_manager.py
+++ b/src/lib/template_manager.py
@@ -19,7 +19,6 @@ class TemplateManager:
             "global_settings": {
                 "icon_zoom": props.icon_zoom,
                 "hdri_path": props.hdri_path,
-                "hdri_strength": props.hdri_strength,
             },
             "cameras": [],
         }


### PR DESCRIPTION
I had left an old implementation for hdri_strength in. It was a global setting before I decided it was better as a "camera" setting.